### PR TITLE
Add support for coc.nvim

### DIFF
--- a/autoload/coc/source/pandoc.vim
+++ b/autoload/coc/source/pandoc.vim
@@ -1,0 +1,26 @@
+function! coc#source#pandoc#init() abort
+	return {
+				\ 'priority': 9,
+				\ 'shortcut': 'pandoc',
+				\ 'filetypes': ['pandoc'],
+				\ 'triggerCharacters': ['@'],
+				\ }
+endfunction
+
+function! coc#source#pandoc#complete(opt, cb) abort
+	let l:classes = []
+	let l:items = []
+	let l:bibs = split(glob('%:p:h/**/*.bib'))
+	for l:bib in l:bibs
+		let l:lines = readfile(l:bib)
+		for l:line in l:lines
+			if l:line =~# '^@\l*{.*,'
+				let l:items += [split(l:line, '{\|,')[1]]
+			endif
+		endfor
+	endfor
+	for l:item in l:items
+		call add(l:classes, {'word': l:item})
+	endfor
+	call a:cb(l:classes)
+endfunction


### PR DESCRIPTION
i find it is a bit hard to use `g:pandoc#after#modules#enabled` to control the support for coc.nvim because it is an autoload plugin. perhaps any one has other solution...
Thanks!